### PR TITLE
Pull contianer-quickstarts url/branch from mdt.yml so that we can use…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Assets to rapidly demonstrate Metrics Driven Transformation (MDT) on the OpenShi
 * Ansible 2.7+
 * OpenShift Environment
 * OpenShift Command Line Tool
+* [JQ](https://stedolan.github.io/jq/)
+* [YQ](https://yq.readthedocs.io/en/latest/)
 
 ## Configuration
 

--- a/playbooks/hygieia.yml
+++ b/playbooks/hygieia.yml
@@ -74,6 +74,7 @@
         return_content: true
         headers:
           Authorization: "Bearer {{ hygieia_auth_token }}"
+          Content-Length: 0
         status_code:
           - 200
       until: hygieia_api_tokens_result.status == 200

--- a/provision.sh
+++ b/provision.sh
@@ -95,7 +95,9 @@ echo
 echo "Deploying Jenkins..."
 echo
 
-ansible-playbook -i "${SCRIPT_BASE_DIR}/dependencies/containers-quickstarts/jenkins-masters/hygieia-plugin/.applier" "${SCRIPT_BASE_DIR}/dependencies/openshift-applier/playbooks/openshift-cluster-seed.yml" -e hygieia_token=$(cat "${SCRIPT_BASE_DIR}/${TEMP_DIRECTORY}/${HYGIEIA_TOKEN_FILE}") -e hygieia_url="http://hygieia.${HYGIEIA_NAMESPACE}.${OCP_SUBDOMAIN}"  -e namespace="${JENKINS_NAMESPACE}"
+repo_url=$(cat vars/mdt.yml | yq '.mdt_git_repositories[] | select(.name == "containers-quickstarts") | .uri')
+repo_branch=$(cat vars/mdt.yml | yq '.mdt_git_repositories[] | select(.name == "containers-quickstarts") | .branch')
+ansible-playbook -i "${SCRIPT_BASE_DIR}/dependencies/containers-quickstarts/jenkins-masters/hygieia-plugin/.applier" "${SCRIPT_BASE_DIR}/dependencies/openshift-applier/playbooks/openshift-cluster-seed.yml" -e hygieia_token=$(cat "${SCRIPT_BASE_DIR}/${TEMP_DIRECTORY}/${HYGIEIA_TOKEN_FILE}") -e hygieia_url="http://hygieia.${HYGIEIA_NAMESPACE}.${OCP_SUBDOMAIN}/api/"  -e namespace="${JENKINS_NAMESPACE}" -e source_code_url=${repo_url} -e source_code_ref=${repo_branch}
 
 echo
 echo "Deploying Application..."

--- a/vars/mdt.yml
+++ b/vars/mdt.yml
@@ -6,9 +6,6 @@ mdt_git_repositories:
   - name: containers-quickstarts
     uri: https://github.com/redhat-cop/containers-quickstarts.git
     branch: master
-  - name: docker-openshift-gitea
-    uri: https://github.com/wkulhanek/docker-openshift-gitea.git
-    branch: master
   - name: container-pipelines
     uri: https://github.com/redhat-cop/container-pipelines.git
     branch: master
@@ -29,11 +26,6 @@ jenkins_service_account: jenkins
 hygieia_dashboard_team_name: Metrics Driven Transformation
 hygieia_dashboard_team_title: Metrics Driven Transformation
 
-# Gitea
-gitea_admin_user: giteaadmin
-gitea_admin_password: redhatmdt
-gitea_admin_email: mdt@redhat.com
-gitea_org_name: mdt
-gitea_sample_repository_name: mdt-example
-gitea_sample_repository_url: https://github.com/redhat-cop/spring-rest.git
-gitea_repo_file: gitea_repo.txt
+# App
+sample_app_repo_url: http://github.com/redhat-cop/spring-rest.git
+sample_app_repo_ref: master


### PR DESCRIPTION
… it to point to other forks/branches

Test this PR using the following method: https://github.com/redhat-cop/containers-quickstarts/pull/174

Set the following in mdt.yml
```
mdt_git_repositories:
  - name: containers-quickstarts
    uri: https://github.com/etsauer/containers-quickstarts.git
    branch: build-mon
...
```

Install new pre-reqs mentioned in README.md

Then run `provision.sh` per README.md
