### PR TITLE
Cleanup README and Provision Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following table describes the various configuration options:
 
 ## Provision
 
-Execute the followig command to provision the environment:
+Execute the following command to provision the environment:
 
 ```
 $ ./provision.sh -s=<subdomain> -g=<github_token>

--- a/provision.sh
+++ b/provision.sh
@@ -23,7 +23,7 @@ do
     -j=*|--jenkins-namespace-=*)
       JENKINS_NAMESPACE="${i#*=}"
       shift;;
-    -n=*|--namespace=*)
+    -h=*|--namespace=*)
       HYGIEIA_NAMESPACE="${i#*=}"
       shift;;
     * )


### PR DESCRIPTION
Will cleanup a typo in README and also have the README match the input of provision.sh, was expecting -n in script, said -h on the README